### PR TITLE
Add Scorecard docs and harden runner

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,10 @@
 name: Scorecard supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '00 18 * * 3'
   push:
@@ -18,10 +21,19 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      # Needed to publish results
       id-token: write
+      contents: read
+      actions: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0d381219ddf674d61a7572ddd19d7941e271515c # v2.9.0
+        with:
+          egress-policy: audit
+
       - name: 'Checkout code'
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -41,6 +53,7 @@ jobs:
           path: results.sarif
           retention-days: 5
 
+      # Upload the results to GitHub's code scanning dashboard.
       - name: 'Upload to code-scanning'
         uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3.26.6
         with:

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Comments have been included to allow override the logic and temporarily test aga
 
 ## Misc local commands
 
+### Running scorecard (via docker)
+
+`docker run -e GITHUB_AUTH_TOKEN=<github PAT> gcr.io/openssf/scorecard --repo=https://github.com/fiaisis/admin-portal`
+
 ### Formatting code via prettier
 
 `yarn run prettier --config prettierrc.json --check **/*.{js,tsx,ts}` - dry run prettier


### PR DESCRIPTION
Follow on to issue #74 
Improve security for running the scorecard action. 

## Description
This PR will
 - Update docs with a command for running scorecard via docker 
 - Add a harden runner step to detect compromised workflow or file tampering when running through github actions 